### PR TITLE
Fixed bug in Pixel constructor

### DIFF
--- a/Pixel.py
+++ b/Pixel.py
@@ -26,7 +26,7 @@ class Pixel:
         y : int
             row of the pixel
         """
-        self.wrapLevels = JESConfig.CONFIG_WRAPPIXELVALUES != '0'
+        self.wrapLevels = JESConfig.getConfigVal("CONFIG_WRAPPIXELVALUES")
         self.image = image
         self.x = x
         self.y = y


### PR DESCRIPTION
When we encapsulated config variables in dictionary we missed updating one place in the Pixel __init__() function.  This was corrected.